### PR TITLE
Update apimanagement-7.md

### DIFF
--- a/apimanagement-7.md
+++ b/apimanagement-7.md
@@ -167,7 +167,7 @@ Remember to click **Save**
 <!-- Inbound -->
 <base />
 <send-request mode="new" response-variable-name="secretResponse" timeout="20" ignore-error="false">
-    <set-url>https://{your-apim-instance}.azure.net/secrets/favoritePerson/?api-version=7.0</set-url>
+    <set-url>https://{your-keyvault-base-uri}.azure.net/secrets/favoritePerson/?api-version=7.0</set-url>
     <set-method>GET</set-method>
     <authentication-managed-identity resource="https://vault.azure.net" />
 </send-request>


### PR DESCRIPTION
The send-request uri should be the key vault base uri and not the APIM instance base uri. verified through the docs and several references and my personal apim testing;